### PR TITLE
"DNS: Now with 99.9% More Existential Dread!"

### DIFF
--- a/dns-simulator.js
+++ b/dns-simulator.js
@@ -53,6 +53,43 @@ document.addEventListener('DOMContentLoaded', (event) => {
         "Embracing the void. Your troubleshooting powers grow stronger."
     ];
 
+    const jokes = [
+        "Why don't DNS servers go to parties? They have too many cache rules!",
+        "How does a DNS server stay in shape? It does nameserver-cises!",
+        "What do you call a DNS lookup that takes forever? A re-curse-ive nightmare!",
+        "Why did the CNAME record break up with the A record? Too much indirection in the relationship!",
+        "What's a DNS admin's favorite dance? The zone transfer!",
+        "How does a DNS server introduce itself? 'Hi, I'm here to resolve your issues!'",
+        "Why was the DNS server feeling down? It had too many unresolved issues!",
+        "What's a DNS server's favorite game? Hide and seek with IP addresses!",
+        "Why did the DNS server go to therapy? It had trouble resolving its parent issues!",
+        "How do DNS servers communicate? Through root channels!"
+    ];
+
+    const diagnoseOptions = [
+        { name: "Check DNS server logs", description: "Dive into the abyss of cryptic log messages." },
+        { name: "Perform nslookup", description: "Ask the DNS oracle for wisdom." },
+        { name: "Verify network connectivity", description: "Ensure the tubes are properly connected." },
+        { name: "Check firewall rules", description: "Navigate the labyrinth of security paranoia." },
+        { name: "Analyze packet captures", description: "Spy on the secret life of packets." }
+    ];
+
+    const fixOptions = [
+        { name: "Restart DNS service", description: "The universal IT solution: turn it off and on again." },
+        { name: "Update DNS records", description: "Play 'find and replace' with the fabric of the internet." },
+        { name: "Flush DNS cache", description: "Give your DNS a digital laxative." },
+        { name: "Reconfigure DNS servers", description: "Rearrange the deck chairs on the Titanic." },
+        { name: "Perform zone transfer", description: "Initiate the great migration of DNS data." }
+    ];
+
+    const escalateOptions = [
+        { name: "Call the network team", description: "Unleash chaos upon another department." },
+        { name: "Summon the DNS elders", description: "Attempt to commune with the ancients of the internet." },
+        { name: "Sacrifice a router to the RFC gods", description: "Appease the deities of networking standards." },
+        { name: "Initiate emergency change request", description: "Brave the perilous waters of corporate bureaucracy." },
+        { name: "Convene a war room meeting", description: "Gather the troops for a symphony of finger-pointing." }
+    ];
+
     let currentProblem = null, problemsSolved = 0, xp = 0, currentLevel = 0, coffeeConsumed = 0;
 
     function logToTerminal(message) {
@@ -63,27 +100,53 @@ document.addEventListener('DOMContentLoaded', (event) => {
 
     function startSimulation() {
         document.getElementById('startButton').style.display = 'none';
-        document.getElementById('actionButtons').style.display = 'block';
+        document.getElementById('actionButtons').style.display = 'flex';
         newProblem();
         logToTerminal("Welcome to DNS purgatory. Abandon all hope, ye who troubleshoot here.");
+        logToTerminal(getRandomElement(jokes));
     }
 
     function newProblem() {
         currentProblem = getRandomElement(problems);
         document.getElementById('problemDisplay').textContent = `Current Crisis: ${currentProblem.name}`;
         logToTerminal("New DNS catastrophe detected: " + currentProblem.name);
+        logToTerminal(getRandomElement(jokes));
         coffeeConsumed++;
     }
 
-    function performAction(action) {
+    function showOptions(type) {
+        const options = type === 'diagnose' ? diagnoseOptions :
+                        type === 'fix' ? fixOptions : escalateOptions;
+        const container = document.getElementById(`${type}Options`);
+        container.innerHTML = '';
+        options.forEach(option => {
+            const button = document.createElement('button');
+            button.textContent = option.name;
+            button.onclick = () => performSpecificAction(type, option);
+            container.appendChild(button);
+        });
+        document.querySelectorAll('.option-buttons').forEach(el => el.style.display = 'none');
+        container.style.display = 'flex';
+    }
+
+    function performSpecificAction(type, option) {
+        logToTerminal(`Attempting to ${type}: ${option.name}`);
+        document.getElementById('actionDescription').textContent = option.description;
+        
         let success = Math.random() < (0.7 - currentProblem.difficulty * 0.1);
         let xpGain = success ? 5 + currentProblem.difficulty : 2;
-        let message = success ? `${action} successful!` : `${action} failed.`;
-        logToTerminal(`${action} action attempted: ${message}`);
+        let message = success ? `${type} successful!` : `${type} failed.`;
+        logToTerminal(message);
+        
+        if (!success) {
+            logToTerminal(getRandomElement(jokes));
+        }
+        
         xp += xpGain;
         coffeeConsumed += Math.floor(Math.random() * 3) + 1;
         updateStats();
-        if (success && action === 'fix') {
+        
+        if (success && type === 'fix') {
             problemsSolved++;
             setTimeout(newProblem, 2000);
         }
@@ -96,6 +159,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
             currentLevel = newLevel;
             document.getElementById('levelDisplay').textContent = `Level ${currentLevel + 1}: ${levels[currentLevel]}`;
             logToTerminal(`Promoted to ${levels[currentLevel]}!`);
+            logToTerminal(getRandomElement(jokes));
         }
         document.getElementById('progressBar').style.width = `${(xp % 50) * 2}%`;
     }
@@ -142,7 +206,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
         welcomeBack.style.color = '#00ff00';
         welcomeBack.style.padding = '20px';
         welcomeBack.style.borderRadius = '10px';
-        welcomeBack.style.fontSize = '28px';
+        welcomeBack.style.fontSize = '24px';
         welcomeBack.style.fontWeight = 'bold';
         welcomeBack.style.zIndex = '1000';
         welcomeBack.style.boxShadow = '0 0 20px #00ff00';
@@ -168,9 +232,9 @@ document.addEventListener('DOMContentLoaded', (event) => {
 
     document.getElementById('themeToggle').addEventListener('click', toggleTheme);
     document.getElementById('startButton').addEventListener('click', startSimulation);
-    document.getElementById('diagnoseButton').addEventListener('click', () => performAction('diagnose'));
-    document.getElementById('fixButton').addEventListener('click', () => performAction('fix'));
-    document.getElementById('escalateButton').addEventListener('click', () => performAction('escalate'));
+    document.getElementById('diagnoseButton').addEventListener('click', () => showOptions('diagnose'));
+    document.getElementById('fixButton').addEventListener('click', () => showOptions('fix'));
+    document.getElementById('escalateButton').addEventListener('click', () => showOptions('escalate'));
     document.getElementById('keepLightTheme').addEventListener('click', applyLightTheme);
     document.getElementById('revertToDarkTheme').addEventListener('click', applyDarkTheme);
 

--- a/dns-simulator.js
+++ b/dns-simulator.js
@@ -127,6 +127,17 @@ document.addEventListener('DOMContentLoaded', (event) => {
         });
         document.querySelectorAll('.option-buttons').forEach(el => el.style.display = 'none');
         container.style.display = 'flex';
+        
+        // Hide main action buttons and show back button
+        document.getElementById('actionButtons').style.display = 'none';
+        document.getElementById('backButton').style.display = 'block';
+    }
+
+    function showMainMenu() {
+        document.querySelectorAll('.option-buttons').forEach(el => el.style.display = 'none');
+        document.getElementById('actionButtons').style.display = 'flex';
+        document.getElementById('backButton').style.display = 'none';
+        document.getElementById('actionDescription').textContent = '';
     }
 
     function performSpecificAction(type, option) {
@@ -235,6 +246,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
     document.getElementById('diagnoseButton').addEventListener('click', () => showOptions('diagnose'));
     document.getElementById('fixButton').addEventListener('click', () => showOptions('fix'));
     document.getElementById('escalateButton').addEventListener('click', () => showOptions('escalate'));
+    document.getElementById('backButton').addEventListener('click', showMainMenu);
     document.getElementById('keepLightTheme').addEventListener('click', applyLightTheme);
     document.getElementById('revertToDarkTheme').addEventListener('click', applyDarkTheme);
 

--- a/index.html
+++ b/index.html
@@ -167,6 +167,10 @@
             margin-top: 10px;
             font-style: italic;
         }
+        #backButton {
+            display: none;
+            margin-top: 10px;
+        }
 
         @media (max-width: 600px) {
             h1 {
@@ -207,6 +211,7 @@
         <div id="diagnoseOptions" class="option-buttons"></div>
         <div id="fixOptions" class="option-buttons"></div>
         <div id="escalateOptions" class="option-buttons"></div>
+        <button id="backButton">Back to Main Menu</button>
         <div id="actionDescription"></div>
         <div id="terminal"></div>
         <div id="statsDisplay">Problems "Solved": 0 | Despair Points: 0 | Coffee Consumed: 0</div>

--- a/index.html
+++ b/index.html
@@ -152,6 +152,21 @@
         #lightThemeMessage button {
             margin-top: 10px;
         }
+        .option-buttons {
+            display: none;
+            flex-direction: column;
+            align-items: center;
+            margin-top: 10px;
+        }
+        .option-buttons button {
+            margin: 5px;
+            width: 100%;
+            max-width: 300px;
+        }
+        #actionDescription {
+            margin-top: 10px;
+            font-style: italic;
+        }
 
         @media (max-width: 600px) {
             h1 {
@@ -189,6 +204,10 @@
             <button id="fixButton">Fix (Tempt Fate)</button>
             <button id="escalateButton">Escalate (Spread Misery)</button>
         </div>
+        <div id="diagnoseOptions" class="option-buttons"></div>
+        <div id="fixOptions" class="option-buttons"></div>
+        <div id="escalateOptions" class="option-buttons"></div>
+        <div id="actionDescription"></div>
         <div id="terminal"></div>
         <div id="statsDisplay">Problems "Solved": 0 | Despair Points: 0 | Coffee Consumed: 0</div>
         <div id="progressBar"></div>


### PR DESCRIPTION
🎭 Tragedy meets comedy in this groundbreaking update to our DNS Simulator! 🎭

What's New:
- Implemented a "Back to Main Menu" button, because sometimes you just need to NOPE out of a DNS crisis.
- Added specific action menus, allowing users to dive deeper into the abyss of troubleshooting despair.
- Increased caffeine intake by 300% (results may vary).

Bug Fixes:
- Fixed an issue where DNS packets were escaping to start new lives as interpretive dancers.
- Resolved a conflict between the A and AAAA records (they're in couple's therapy now).

Known Issues:
- The "Summon DNS Elders" function may occasionally open a portal to the void. Use with caution.
- Coffee consumption tracking may be off by a factor of "I've lost count."

This update is guaranteed to increase your DNS troubleshooting skills or your sanity back!*

*Sanity not actually refundable. Terms and conditions apply. Side effects may include uncontrollable laughter, increased caffeine dependency, and the urge to debug your home router at 3 AM.

Reviewers: Please check if your will to live is still intact after testing. If not, that means it's working as intended.